### PR TITLE
fix(runtime): resolve component identity and keyed insertion context loss

### DIFF
--- a/packages/humn/src/__tests__/rendering.test.js
+++ b/packages/humn/src/__tests__/rendering.test.js
@@ -1,6 +1,6 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
-import { Cortex, css, h, mount } from '../index'
+import { Cortex, css, h, mount, onCleanup, onMount } from '../index'
 
 async function flushUpdates() {
   await Promise.resolve()
@@ -296,7 +296,7 @@ describe('Rendering & Reactivity', () => {
         `
       /* Descendant selector should NOT match root */
       header .logo { height: 50px; } 
-
+  
       @keyframes fade {
         from { opacity: 0; }
         to { opacity: 1; }
@@ -316,5 +316,145 @@ describe('Rendering & Reactivity', () => {
       expect(styleTag.textContent).toContain('from { opacity: 0; }')
       expect(styleTag.textContent).not.toContain(`from&`)
     })
+  })
+
+  it('replaces different component types with the same root element tag', async () => {
+    const store = new Cortex({
+      memory: {
+        showCreateForm: false,
+      },
+      synapses: (set) => ({
+        toggle() {
+          set((state) => {
+            state.showCreateForm = !state.showCreateForm
+          })
+        },
+      }),
+    })
+
+    const detailMountSpy = vi.fn()
+    const detailCleanupSpy = vi.fn()
+    const createMountSpy = vi.fn()
+    const createCleanupSpy = vi.fn()
+
+    const CreateCustomer = () => {
+      onMount(createMountSpy)
+      onCleanup(createCleanupSpy)
+      return h('aside', { class: 'create' }, [
+        h('form', {}, [
+          h('input', { value: 'New customer' }),
+          h('button', {}, 'Create'),
+        ]),
+      ])
+    }
+
+    const AccountDetail = () => {
+      onMount(detailMountSpy)
+      onCleanup(detailCleanupSpy)
+      return h('aside', { class: 'detail' }, [
+        h('section', {}, [
+          h('h2', {}, 'Account detail'),
+          h('div', {}, 'Stats'),
+        ]),
+        h('div', { class: 'actions' }, [h('button', {}, 'Log touch')]),
+      ])
+    }
+
+    const App = () => {
+      const { showCreateForm } = store.memory
+
+      return h('main', {}, [
+        showCreateForm ? h(CreateCustomer) : h(AccountDetail),
+      ])
+    }
+
+    const target = document.createElement('div')
+    mount(target, App)
+
+    expect(target.querySelector('aside.detail')).not.toBeNull()
+
+    // Wait for setTimeouts inside scheduleMountHooks to resolve (if any)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(detailMountSpy).toHaveBeenCalledTimes(1)
+    expect(detailCleanupSpy).toHaveBeenCalledTimes(0)
+    expect(createMountSpy).toHaveBeenCalledTimes(0)
+    expect(createCleanupSpy).toHaveBeenCalledTimes(0)
+
+    store.synapses.toggle()
+    await Promise.resolve()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(target.querySelector('aside.create')).not.toBeNull()
+    expect(target.querySelector('aside.detail')).toBeNull()
+
+    expect(detailCleanupSpy).toHaveBeenCalledTimes(1)
+    expect(createMountSpy).toHaveBeenCalledTimes(1)
+
+    store.synapses.toggle()
+    await Promise.resolve()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(target.querySelector('aside.detail')).not.toBeNull()
+    expect(target.querySelector('aside.create')).toBeNull()
+
+    expect(createCleanupSpy).toHaveBeenCalledTimes(1)
+    expect(detailMountSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('should preserve parent and update state for newly inserted keyed components', async () => {
+    const store = new Cortex({
+      memory: {
+        items: [],
+        counter: 0,
+      },
+      synapses: (set) => ({
+        addItem: (id) =>
+          set((s) => {
+            s.items.push({ id })
+          }),
+        increment: () =>
+          set((s) => {
+            s.counter++
+          }),
+      }),
+    })
+
+    const KeyedChild = ({ id }) => {
+      // Access store.memory.counter to subscribe to changes and conditionally render root tag
+      const tag = store.memory.counter % 2 === 0 ? 'li' : 'div'
+      return h(tag, { 'data-id': String(id) }, `Count: ${store.memory.counter}`)
+    }
+
+    const App = () =>
+      h(
+        'ul',
+        {},
+        store.memory.items.map((item) =>
+          h(KeyedChild, { id: item.id, key: item.id }),
+        ),
+      )
+
+    const target = document.createElement('div')
+    mount(target, App)
+
+    // Initially no items
+    expect(target.querySelectorAll('li').length).toBe(0)
+
+    // Add a new keyed child - this goes through insertNewKeyedChild
+    store.synapses.addItem(42)
+    await Promise.resolve()
+
+    expect(target.querySelector('[data-id="42"]')).not.toBeNull()
+    expect(target.querySelector('[data-id="42"]').tagName).toBe('LI')
+    expect(target.querySelector('[data-id="42"]').textContent).toBe('Count: 0')
+
+    // Now increment the counter. This triggers a state update inside the KeyedChild component, changing its root tag.
+    store.synapses.increment()
+    await Promise.resolve()
+
+    expect(target.querySelector('[data-id="42"]')).not.toBeNull()
+    expect(target.querySelector('[data-id="42"]').tagName).toBe('DIV')
+    expect(target.querySelector('[data-id="42"]').textContent).toBe('Count: 1')
   })
 })

--- a/packages/humn/src/runtime/patch.js
+++ b/packages/humn/src/runtime/patch.js
@@ -71,12 +71,50 @@ export function mountComponent({ index, newVNode, oldVNode, parent }) {
   instance.vNode = newVNode
 }
 
+function isComponentVNode(vNode) {
+  return typeof vNode?.tag === 'function'
+}
+
+function isDifferentComponent(newVNode, oldVNode) {
+  return (
+    isComponentVNode(newVNode) &&
+    isComponentVNode(oldVNode) &&
+    newVNode.tag !== oldVNode.tag
+  )
+}
+
 export function patch(parent, newVNode, oldVNode, index = 0) {
   // Removal must clean up recursively so component hooks cannot leak.
   if (newVNode === undefined || newVNode === null) {
     const el = oldVNode.el || parent.childNodes[index]
     runUnmount(oldVNode)
-    if (el) parent.removeChild(el)
+    if (el && el.parentNode === parent) parent.removeChild(el)
+    return
+  }
+
+  if (isDifferentComponent(newVNode, oldVNode)) {
+    const oldEl = oldVNode.el || oldVNode.child?.el || parent.childNodes[index]
+    runUnmount(oldVNode)
+
+    const fragment = document.createDocumentFragment()
+    mountComponent({ index: 0, newVNode, oldVNode: null, parent: fragment })
+
+    newVNode.instance.parent = parent
+    newVNode.instance.index = index
+
+    const replacement = newVNode.el || fragment.firstChild
+
+    if (oldEl && oldEl.parentNode === parent) {
+      parent.replaceChild(replacement, oldEl)
+    } else {
+      const current = parent.childNodes[index]
+      if (current && current.parentNode === parent) {
+        parent.replaceChild(replacement, current)
+      } else {
+        parent.appendChild(replacement)
+      }
+    }
+
     return
   }
 

--- a/packages/humn/src/runtime/patch.js
+++ b/packages/humn/src/runtime/patch.js
@@ -86,7 +86,7 @@ function isDifferentComponent(newVNode, oldVNode) {
 export function patch(parent, newVNode, oldVNode, index = 0) {
   // Removal must clean up recursively so component hooks cannot leak.
   if (newVNode === undefined || newVNode === null) {
-    const el = oldVNode.el || parent.childNodes[index]
+    const el = oldVNode?.el || parent.childNodes[index]
     runUnmount(oldVNode)
     if (el && el.parentNode === parent) parent.removeChild(el)
     return

--- a/packages/humn/src/runtime/reconcile-children.js
+++ b/packages/humn/src/runtime/reconcile-children.js
@@ -1,5 +1,3 @@
-import { createElement, getNamespace } from './create-element.js'
-
 export function hasKeys(children) {
   return children && children.some((child) => child?.props?.key != null)
 }
@@ -65,7 +63,7 @@ function reconcileKeyedChildren({
       return
     }
 
-    insertNewKeyedChild({ index, newChild, parent })
+    insertNewKeyedChild({ index, newChild, parent, patchNode })
   })
 
   removeStaleKeyedChildren({ keyedChildren, parent, runUnmount })
@@ -102,16 +100,15 @@ function patchExistingKeyedChild({
     parent.insertBefore(element, domChildAtIndex)
 }
 
-function insertNewKeyedChild({ index, newChild, parent }) {
-  const newElement = createElement(newChild, getNamespace(parent))
+function insertNewKeyedChild({ index, newChild, parent, patchNode }) {
+  patchNode(parent, newChild, null, index)
+
+  const newElement = newChild.el
   const domChildAtIndex = parent.childNodes[index]
 
-  if (domChildAtIndex) {
+  if (newElement && domChildAtIndex && domChildAtIndex !== newElement) {
     parent.insertBefore(newElement, domChildAtIndex)
-    return
   }
-
-  parent.appendChild(newElement)
 }
 
 function removeStaleKeyedChildren({ keyedChildren, parent, runUnmount }) {


### PR DESCRIPTION
## Description
This PR resolves two major bugs in the Humn virtual DOM engine:

1. **Different Component Identity Check**: If two component constructors at the same position differ (even if they both render the same root element tag, e.g. `<aside>`), the runtime now correctly unmounts the old component and mounts and replaces it with the new component, instead of patching them in place.
2. **Keyed Component Insertion Context**: Keyed children are now routed through the standard `patchNode` path instead of calling `createElement` directly. This ensures that the component's parent and index context are perfectly retained, so that state updates inside keyed components continue targeting the correct real DOM nodes.

## Checklist
- [x] Reproducing tests added and verified.
- [x] Full test suite passing.
- [x] Formatting and linter checks pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced component switching when toggling between different component types.
  * Improved handling of keyed children with dynamic root elements.

* **Tests**
  * Added test coverage for component mounting and cleanup during type changes.
  * Added test coverage for keyed child reconciliation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->